### PR TITLE
[custom cooldown] fetch config.yml cooldown timer, message reload

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.nicolas'
-version = '1.0-SNAPSHOT'
+version = '1.1.0'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/nicolas/rd_anunciar/Main.kt
+++ b/src/main/java/com/nicolas/rd_anunciar/Main.kt
@@ -2,6 +2,8 @@ package com.nicolas.rd_anunciar
 
 import com.nicolas.rd_anunciar.command.AnnounceCommand
 import com.nicolas.rd_anunciar.database.AnnouncementDatabase
+import com.nicolas.rd_anunciar.updater.UpdateChecker
+import com.nicolas.rd_anunciar.utils.Constants
 import org.bukkit.Bukkit
 import org.bukkit.plugin.java.JavaPlugin
 import java.sql.SQLException
@@ -11,6 +13,14 @@ class Main : JavaPlugin() {
     private var announcementDatabase: AnnouncementDatabase? = null
 
     override fun onEnable() {
+
+        UpdateChecker(this, Constants.RESOURCE_ID).getVersion { version ->
+            if (this.description.version.equals(version)) {
+                logger.info("Nenhuma atualização disponível.")
+            } else {
+                logger.info("Existe uma atualização disponível!")
+            }
+        }
 
         if (!dataFolder.exists()) {
             dataFolder.mkdirs()

--- a/src/main/java/com/nicolas/rd_anunciar/Main.kt
+++ b/src/main/java/com/nicolas/rd_anunciar/Main.kt
@@ -2,6 +2,7 @@ package com.nicolas.rd_anunciar
 
 import com.nicolas.rd_anunciar.command.AnnounceCommand
 import com.nicolas.rd_anunciar.database.AnnouncementDatabase
+import com.nicolas.rd_anunciar.listener.AdminJoinListener
 import com.nicolas.rd_anunciar.updater.UpdateChecker
 import com.nicolas.rd_anunciar.utils.Constants
 import org.bukkit.Bukkit
@@ -11,6 +12,10 @@ import java.sql.SQLException
 class Main : JavaPlugin() {
 
     private var announcementDatabase: AnnouncementDatabase? = null
+    var hasVersionAvailable: HashMap<String, Boolean> = hashMapOf(
+        Constants.HAS_VERSION to false
+    )
+    var versions: HashMap<String, String> = hashMapOf()
 
     override fun onEnable() {
 
@@ -18,6 +23,8 @@ class Main : JavaPlugin() {
             if (this.description.version.equals(version)) {
                 logger.info("Nenhuma atualização disponível.")
             } else {
+                hasVersionAvailable[Constants.HAS_VERSION] = true
+                versions[Constants.NEW_VERSION] = version
                 logger.info("Existe uma atualização disponível!")
             }
         }
@@ -29,7 +36,13 @@ class Main : JavaPlugin() {
         connectionDatabase()
         server.getPluginCommand("anunciar").executor = AnnounceCommand(this)
 
+        registerEvents()
+
         saveDefaultConfig()
+    }
+
+    private fun registerEvents() {
+        Bukkit.getPluginManager().registerEvents(AdminJoinListener(this), this)
     }
 
     private fun connectionDatabase() {
@@ -49,5 +62,8 @@ class Main : JavaPlugin() {
         } catch (exception: SQLException) {
             exception.printStackTrace()
         }
+        hasVersionAvailable.clear()
+        versions.clear()
     }
+
 }

--- a/src/main/java/com/nicolas/rd_anunciar/command/AnnounceCommand.kt
+++ b/src/main/java/com/nicolas/rd_anunciar/command/AnnounceCommand.kt
@@ -17,7 +17,7 @@ class AnnounceCommand(private val plugin: Main) : CommandExecutor {
 
         if (args.isNotEmpty() && args[0] == "reload" && player.hasPermission("nksanunciar.reload")) {
             plugin.reloadConfig()
-            player.sendMessage(TextColorUtil.text("&6&lnksAnunciar &7- &aPlugin recarregado com sucesso!"))
+            player.sendMessage(TextColorUtil.text(plugin.config.getString("mensagens.reload")))
             return true
         }
 
@@ -52,7 +52,7 @@ class AnnounceCommand(private val plugin: Main) : CommandExecutor {
     private fun showElapsedTime(currentTime: Long, lasTimeUpdate: Long, player: Player) {
 
         val elapsedTime = currentTime - lasTimeUpdate
-        val remainingTime = TimeUnit.MINUTES.toMillis(5) - elapsedTime
+        val remainingTime = TimeUnit.MINUTES.toMillis(plugin.config.getLong("config.cooldown-timer")) - elapsedTime
 
         if (remainingTime > 0) {
 

--- a/src/main/java/com/nicolas/rd_anunciar/command/AnnounceCommand.kt
+++ b/src/main/java/com/nicolas/rd_anunciar/command/AnnounceCommand.kt
@@ -3,6 +3,7 @@ package com.nicolas.rd_anunciar.command
 import com.nicolas.rd_anunciar.Main
 import com.nicolas.rd_anunciar.instance.Announcement
 import com.nicolas.rd_anunciar.utils.TextColorUtil
+import com.nicolas.rd_anunciar.utils.linkChecker
 import org.bukkit.command.Command
 import org.bukkit.command.CommandExecutor
 import org.bukkit.command.CommandSender
@@ -19,6 +20,15 @@ class AnnounceCommand(private val plugin: Main) : CommandExecutor {
             plugin.reloadConfig()
             player.sendMessage(TextColorUtil.text(plugin.config.getString("mensagens.reload")))
             return true
+        }
+
+        if (args.isNotEmpty()) {
+            args.forEach {
+                if (it.linkChecker()) {
+                    player.sendMessage(TextColorUtil.text("&cVocê não pode enviar link no anúncio."))
+                    return true
+                }
+            }
         }
 
         val currentTime = System.currentTimeMillis()
@@ -64,9 +74,7 @@ class AnnounceCommand(private val plugin: Main) : CommandExecutor {
             val resultTextFormatted = firstReplace.replace("{remainSeconds}", remainSeconds.toString())
 
             player.sendMessage(
-                TextColorUtil.text(
-                    "${plugin.config.getString("mensagens.anuncio")} $resultTextFormatted"
-                )
+                TextColorUtil.text("${plugin.config.getString("mensagens.anuncio")} $resultTextFormatted")
             )
         }
     }

--- a/src/main/java/com/nicolas/rd_anunciar/listener/AdminJoinListener.kt
+++ b/src/main/java/com/nicolas/rd_anunciar/listener/AdminJoinListener.kt
@@ -1,0 +1,24 @@
+package com.nicolas.rd_anunciar.listener
+
+import com.nicolas.rd_anunciar.Main
+import com.nicolas.rd_anunciar.utils.Constants
+import com.nicolas.rd_anunciar.utils.TextColorUtil
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.player.PlayerJoinEvent
+
+class AdminJoinListener(private val plugin: Main) : Listener {
+
+    @EventHandler
+    fun onAdminJoin(playerJoinEvent: PlayerJoinEvent) {
+
+        if (playerJoinEvent.player.isOp && plugin.hasVersionAvailable[Constants.HAS_VERSION]!!) {
+            playerJoinEvent.player.sendMessage(
+                TextColorUtil.text(
+                    "\n&a[NksAnunciar] &7Uma nova atualização está disponível: " +
+                            "&a${plugin.versions[Constants.NEW_VERSION]} &7e você está na &a${plugin.description.version}\n&f"
+                )
+            )
+        }
+    }
+}

--- a/src/main/java/com/nicolas/rd_anunciar/updater/UpdateChecker.kt
+++ b/src/main/java/com/nicolas/rd_anunciar/updater/UpdateChecker.kt
@@ -1,0 +1,32 @@
+package com.nicolas.rd_anunciar.updater
+
+import com.nicolas.rd_anunciar.Main
+import org.bukkit.Bukkit
+import java.io.IOException
+import java.net.URL
+import java.util.Scanner
+import java.util.function.Consumer
+
+class UpdateChecker(
+    private val plugin: Main,
+    private val resourceId: Int
+) {
+
+    fun getVersion(consumer: Consumer<String>) {
+        Bukkit.getScheduler().runTaskAsynchronously(plugin) {
+            try {
+                val inputStream = URL("$BASE_URL$resourceId/~").openStream()
+                val scanner = Scanner(inputStream)
+                if (scanner.hasNext()) {
+                    consumer.accept(scanner.next())
+                }
+            } catch (exception: IOException) {
+                plugin.logger.info("Não foi possível buscar por atualizações: ${exception.message}")
+            }
+        }
+    }
+
+    companion object {
+        const val BASE_URL = "https://api.spigotmc.org/legacy/update.php?resource="
+    }
+}

--- a/src/main/java/com/nicolas/rd_anunciar/utils/Constants.kt
+++ b/src/main/java/com/nicolas/rd_anunciar/utils/Constants.kt
@@ -4,4 +4,7 @@ object Constants {
 
     const val RESOURCE_ID = 116823
 
+    const val HAS_VERSION = "version"
+    const val NEW_VERSION = "new_version"
+
 }

--- a/src/main/java/com/nicolas/rd_anunciar/utils/Constants.kt
+++ b/src/main/java/com/nicolas/rd_anunciar/utils/Constants.kt
@@ -1,0 +1,7 @@
+package com.nicolas.rd_anunciar.utils
+
+object Constants {
+
+    const val RESOURCE_ID = 116823
+
+}

--- a/src/main/java/com/nicolas/rd_anunciar/utils/LinkChecker.kt
+++ b/src/main/java/com/nicolas/rd_anunciar/utils/LinkChecker.kt
@@ -1,0 +1,7 @@
+package com.nicolas.rd_anunciar.utils
+
+fun String.linkChecker(): Boolean {
+
+    val linkRegex = """(https?://\S+|www\.\S+\.\S+|\b\S+\.\S+\b)""".toRegex()
+    return linkRegex.containsMatchIn(this)
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -61,4 +61,5 @@ mensagens:
   permissao: '&cVocê não tem permissão para utilizar este comando.'
   tempo-decorrido: '&cAguarde: {remainMinutes} minutos e {remainSeconds} segundos para usar este comando novamente'
   anuncio: '&6[Anuncio]'
-  ajuda: '&eUse /anunciar (mensagem)"'
+  ajuda: '&eUse /anunciar (mensagem)'
+  reload: '&6&lnksAnunciar &7- &aPlugin recarregado com sucesso!'


### PR DESCRIPTION
## Descrição, Motivação, Contexto

- Quando houver uma versão disponível do plugin, notificar para quem tiver `op` no servidor, obs: (_`os check de versão, vão ser verificados diretamente da api do spigot quando um novo .jar for atualizado`_)
- Bloquear links: agora quando alguém enviar um link com: (`https, https:// www., .com .any .. etc`)  no /anúnciar, não será mais possível.

![Screenshot 2024-05-21 100527](https://github.com/aleixo-dev/NksAnunciar/assets/75820713/9214b21a-c24a-4c0a-9ba4-99c46a23bf04)
![Screenshot 2024-05-21 100621](https://github.com/aleixo-dev/NksAnunciar/assets/75820713/2747d3f0-8290-41f2-b65c-cac60eea8cac)
